### PR TITLE
Add spouse name to family events in the timeline

### DIFF
--- a/src/family_tree_view_timeline.py
+++ b/src/family_tree_view_timeline.py
@@ -373,8 +373,14 @@ class FamilyTreeViewTimeline:
                 if isinstance(rel[-1], Person):
                     relative_name = name_displayer.display_name(rel[-1].get_primary_name())
                     markup = f"{event_age_str}{event_type} of {relationship_type} <b>{relative_name}</b>{description}:\n{event_date_str}{event_place_str}"
-                else:
-                    markup = f"{event_age_str}{event_type} of <b>{relationship_type}</b>{description}:\n{event_date_str}{event_place_str}"
+                else: # Family
+                    spouse_name = "Unknown"
+                    for spouse_handle in [rel[-1].get_father_handle(), rel[-1].get_mother_handle()]:
+                        if spouse_handle is not None and spouse_handle != self.obj.get_handle():
+                            spouse = self.ftv.get_person_from_handle(spouse_handle)
+                            spouse_name = name_displayer.display_name(spouse.get_primary_name())
+                            break
+                    markup = f"{event_age_str}{event_type} with <b>{spouse_name}</b>{description}:\n{event_date_str}{event_place_str}"
                 class_name = "ftv-timeline-event-relatives"
             event_label = Gtk.Label()
             event_label.set_markup(markup)

--- a/src/family_tree_view_timeline.py
+++ b/src/family_tree_view_timeline.py
@@ -338,7 +338,8 @@ class FamilyTreeViewTimeline:
             if event_place_str is None: # no place
                 event_place_str = ""
             else:
-                event_place_str = ",\n" + event_place_str
+                if event_place_str != "": # have a place string
+                    event_place_str = ",\n" + event_place_str
 
             if rel_type is None: # primary event
                 markup = f"{event_age_str}<b>{event_type}</b>{description}:\n{event_date_str}{event_place_str}"

--- a/src/family_tree_view_timeline.py
+++ b/src/family_tree_view_timeline.py
@@ -338,8 +338,7 @@ class FamilyTreeViewTimeline:
             if event_place_str is None: # no place
                 event_place_str = ""
             else:
-                if event_place_str != "": # have a place string
-                    event_place_str = ",\n" + event_place_str
+                event_place_str = ",\n" + event_place_str
 
             if rel_type is None: # primary event
                 markup = f"{event_age_str}<b>{event_type}</b>{description}:\n{event_date_str}{event_place_str}"


### PR DESCRIPTION
Some time ago (17 Jan 2025, post #228) there was a request in the Gramps forum: 'in the FTV panel timeline, the “marriage” events should show the spouse name'

This PR provides the spouse's name for family events.

![spouse name after](https://github.com/user-attachments/assets/33a6b7f1-b909-4267-b264-01725fd98b94)
