### PR TITLE
Add URL submenu

### DIFF
--- a/src/family_tree_view.py
+++ b/src/family_tree_view.py
@@ -947,6 +947,20 @@ class FamilyTreeView(NavigationView, Callback):
                 self.widget_manager.info_box_manager.close_info_box()
                 self.rebuild_tree()
 
+    def get_person_urls(self, person_handle):
+        person = self.get_person_from_handle(person_handle)
+        if person is None:
+            return []
+
+        urls = []
+        for url in person.get_url_list():
+            path = url.get_path()
+            description = url.get_description()
+            if description is None or description == "":
+                description = str(url.get_type())
+            urls.append((description, path))
+        return urls
+
     def set_active_person(self, person_handle):
         if self.get_person_from_handle(person_handle) is not None:
             self.widget_manager.info_box_manager.close_info_box()

--- a/src/family_tree_view_widget_manager.py
+++ b/src/family_tree_view_widget_manager.py
@@ -34,6 +34,7 @@ from gramps.gen.lib import Person
 from gramps.gen.utils.alive import probably_alive
 from gramps.gen.utils.db import get_birth_or_fallback, get_death_or_fallback, get_marriage_or_fallback, get_divorce_or_fallback
 from gramps.gen.utils.string import format_gender
+from gramps.gui.display import display_url
 from gramps.gui.utils import color_graph_box, color_graph_family, get_contrast_color, hex_to_rgb, hex_to_rgb_float, rgb_to_hex
 
 from date_display_compact import get_date as get_date_compact
@@ -1012,6 +1013,21 @@ class FamilyTreeViewWidgetManager:
             self.ftv.edit_person(person_handle)
         )
         self.menu.append(menu_item)
+
+        urls = self.ftv.get_person_urls(person_handle)
+        if len(urls) > 0:
+            submenu = Gtk.Menu()
+            menu_item = Gtk.MenuItem(label=_("Open URL"))
+            menu_item.set_submenu(submenu)
+            menu_item.show()
+            self.menu.append(menu_item)
+
+            for (name, path) in urls:
+                menu_item = Gtk.MenuItem(label=name)
+                menu_item.connect("activate", lambda *_args:
+                    display_url(path)
+                )
+                submenu.append(menu_item)
 
         menu_item = Gtk.MenuItem(label=_("Set as home person"))
         menu_item.connect("activate", lambda *_args:


### PR DESCRIPTION
This adds a submenu in the context menu for people that have URLs. I add URLs to online trees (familysearch, ...) in the URL section of people, and this submenu is useful to access them quickly.